### PR TITLE
Remove getting started help section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,3 @@ A few resources to get you started if this is your first Flutter project:
 - [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
 - [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
 
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.


### PR DESCRIPTION
Removed help section for getting started with Flutter.